### PR TITLE
Update README.Rmd

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -48,7 +48,7 @@ library("httr")
 token <- Sys.getenv("GITHUB_GRAPHQL_TOKEN")
 cli <- GraphqlClient$new(
   url = "https://api.github.com/graphql",
-  headers = add_headers(Authorization = paste0("Bearer ", token))
+  headers = add_headers(Authorization = paste0("token", " ", token))
 )
 ```
 


### PR DESCRIPTION
the first argument in the authorization string is supposed to be 'token' I believe followed by a space, followed by the token.  (I assume 'Bearer' is a username.