### PR TITLE
Use schema_url if not null (x not defined)

### DIFF
--- a/R/client.R
+++ b/R/client.R
@@ -175,7 +175,8 @@ GraphqlClient <- R6::R6Class(
       if (!is.null(schema_url) || is.null(schema_file)) {
         self$schema <- parze(
           cont(
-            gh_GET(if (is.null(schema_url)) self$url else x, self$headers, ...)
+            gh_GET(if (is.null(schema_url)) self$url else schema_url,
+                   self$headers, ...)
           )
         )
       } else {


### PR DESCRIPTION
Small bugfix in `load_schema()`