### PR TITLE
Variable support on query

### DIFF
--- a/R/client.R
+++ b/R/client.R
@@ -211,13 +211,18 @@ GraphqlClient <- R6::R6Class(
 
     #' @description execute the query
     #' @param query (character) a query, of class `query` or `fragment`
+    #' @param variables (list) named list with query variables values
     #' @param ... curl options passed on to [httr::POST()]
     #' @return character string of response, if successful
-    exec = function(query, ...) {
+    exec = function(query, variables, ...) {
+      parsed_query <- gsub("\n", "", private$handle_query(query))
+      body <- list(query = parsed_query)
+      if (!missing(variables)) 
+        body$variables = variables
       cont(
         gh_POST(
           self$url,
-          gsub("\n", "", private$handle_query(query)),
+          body,
           self$headers, ...)
       )
     },

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -2,10 +2,10 @@ gh_base <- function() "https://api.github.com/graphql"
 
 ct <- function(x) Filter(Negate(is.null), x)
 
-gh_POST <- function(url, query, ...){
+gh_POST <- function(url, body, ...){
   temp <- httr::POST(
     url,
-    body = list(query = query),
+    body = body,
     #ghql_auth(),
     encode = "json",
     ...)


### PR DESCRIPTION
As it was discussed on #18, a GraphQL best practice is to parameterize a query by a variable. 
The changes made here add the variables on query support.
Example
```R
load(ghql)
qry <- Query$new()
qry$query('getgeninfo', 'query getGeneInfo($genId: String!){
  geneInfo(geneId: $genId) {
    id
    symbol
    chromosome
    start
    end
    bioType
    __typename
  }
}')
variables <- list(
  'genId' = 'ENSG00000137033'
)
cli <- GraphqlClient$new(url='http://genetics-api.opentargets.io/graphql')
cli$exec(qry$getgeninfo, variables)
```