### PR TITLE
Enable comments in queries and fragments (#25)

### DIFF
--- a/R/client.R
+++ b/R/client.R
@@ -220,7 +220,7 @@ GraphqlClient <- R6::R6Class(
     #' @param ... curl options passed on to [crul::verb-POST]
     #' @return character string of response, if successful
     exec = function(query, variables, encoding = "UTF-8", ...) {
-      parsed_query <- gsub("\n", "", private$handle_query(query))
+      parsed_query <- private$handle_query(query)
       body <- list(query = parsed_query)
       if (private$has_variables(body$query)) {
         if (missing(variables))


### PR DESCRIPTION
## Description
This PR enables making comments with `#` (see [GraphQL spec](https://spec.graphql.org/June2018/#sec-Comments)) as discussed in #25. This is particularly useful for longer queries and more complex queries. 

It seems like this was previously not possible because in the `exec` function, newlines (`\n`) were removed, hence resulting in invalid JSON (hence the "unexpected end of document" error). 

## Related Issue
fix #25 

## Example
It is now possible to add comments to query and fragment strings (see new, extended test in `test-GraphQLClient.R` based on code from [this post](https://blog.logrocket.com/graphql-fragments-explained/)): 

```r
aa <- GraphqlClient$new(
  url = "https://api.github.com/graphql",
  headers = list(Authorization = paste0("Bearer ", token))
)

frag <- Fragment$new()
frag$fragment('ownerInfo', '
  fragment on RepositoryOwner {
    # we can also comment inside a fragment
    id
    avatarUrl
    resourcePath # that is nice
    url
}')

qry <- Query$new()
qry$query('repos', '{
  # let\'s get two repositories using our fragment
  ghql: repository(owner: "ropensci", name: "ghql") {
    name # the name of the repository
    owner {
      ...ownerInfo # fragment
    }
  }
  jsonlite: repository(owner: "jeroen", name: "jsonlite") {
    name
    owner {
    ...ownerInfo # fragment
    }
  }
}')
qry$add_fragment('repos', frag$fragments$ownerInfo)


# execute method
out <- aa$exec(qry$queries$repos)
```

