### PR TITLE
allow underscores in query variables

### DIFF
--- a/R/client.R
+++ b/R/client.R
@@ -224,7 +224,7 @@ GraphqlClient <- R6::R6Class(
       body <- list(query = parsed_query)
       if (private$has_variables(body$query)) {
         if (missing(variables))
-          stop(sprintf("query has variables and not one passsed"), call. = FALSE)
+          stop(sprintf("query has variables and not one passed"), call. = FALSE)
         else
           private$verify_variables(body$query, variables)
           body$variables = variables  
@@ -247,7 +247,7 @@ GraphqlClient <- R6::R6Class(
 
   private = list(
     # @field .var_regex variable regexp 
-    .var_regex = '\\$([[:alnum:]]+)',
+    .var_regex = '\\$([_A-Za-z][_0-9A-Za-z]*)',
 
     # @description rewrite query if there is fragments, leave equal otherwise
     # @param x (character) a query, of class `query` or `fragment`

--- a/R/client.R
+++ b/R/client.R
@@ -227,7 +227,7 @@ GraphqlClient <- R6::R6Class(
           stop(sprintf("query has variables and not one passed"), call. = FALSE)
         else
           private$verify_variables(body$query, variables)
-          body$variables = variables  
+          body$variables = ct(variables)
       }
       cont(
         gh_POST(
@@ -288,8 +288,8 @@ GraphqlClient <- R6::R6Class(
         )
       )
       for (v in vars) {
-        if (is.null(variables[[v]]))
-          stop(sprintf("variable `%s` is null or not found in variables", v), call. = FALSE)
+        if (!v %in% names(variables))
+          stop(sprintf("variable `%s` is not found in variables", v), call. = FALSE)
       }
     }
   )

--- a/R/client.R
+++ b/R/client.R
@@ -247,7 +247,7 @@ GraphqlClient <- R6::R6Class(
 
   private = list(
     # @field .var_regex variable regexp 
-    .var_regex = '\\$([_A-Za-z][_0-9A-Za-z]*)',
+    .var_regex = '\\$([[:alpha:]_]\\w*)',
 
     # @description rewrite query if there is fragments, leave equal otherwise
     # @param x (character) a query, of class `query` or `fragment`

--- a/tests/testthat/test-GraphqlClient.R
+++ b/tests/testthat/test-GraphqlClient.R
@@ -126,42 +126,49 @@ test_that("GraphqlClient class fails well", {
 })
 
 test_that("GraphqlClient construction works with parameters", {
-      skip_on_cran()
-      
-      token <- Sys.getenv("GITHUB_GRAPHQL_TOKEN")
-      aa <- GraphqlClient$new(
-          url = "https://api.github.com/graphql",
-          headers = list(Authorization = paste0("Bearer ", token))
-      )
-      
-      # ping method
-      expect_true(aa$ping())
-            
-      qry <- Query$new()
-      qry$query('repos', 'query getRepo($owner_name: String!, $repo: String!){
-                repository(owner: $owner_name, name: $repo) {
-                  name
-                }
-              }')
-      params <- list(owner_name = "ropensci", repo = "ghql")
-      # execute method
-      out <- aa$exec(qry$queries$repos, variables = params)
-      expect_is(out, "character")
-      expect_match(out, "ghql")
-      
-      parsed <- jsonlite::fromJSON(out)
-      expect_is(parsed, "list")
-      expect_named(parsed, "data")
-      expect_is(parsed$data$repository, "list")
-      expect_identical(parsed$data$repository$name, params$repo)
-      
-      # no variables
-      expect_error(aa$exec(qry$queries$repos), "not one passed")
-      
-      # missing variable
-      expect_error(
-          aa$exec(qry$queries$repos, variables = list(owner_name = "ropensci")), 
-          "variable `repo` is null")
-      
-      
-    })
+  skip_on_cran()
+  
+  token <- Sys.getenv("GITHUB_TOKEN")
+  aa <- GraphqlClient$new(
+      url = "https://api.github.com/graphql",
+      headers = list(Authorization = paste0("Bearer ", token))
+  )
+  
+  # ping method
+  expect_true(aa$ping())
+        
+  qry <- Query$new()
+  qry$query('repos', 'query getRepo($owner_name: String!, $repo: String!) {
+            repository(owner: $owner_name, name: $repo) {
+              name
+            }
+          }')
+  params <- list(owner_name = "ropensci", repo = "ghql")
+  # execute method
+  out <- aa$exec(qry$queries$repos, variables = params)
+  expect_is(out, "character")
+  expect_match(out, "ghql")
+  
+  parsed <- jsonlite::fromJSON(out)
+  expect_is(parsed, "list")
+  expect_named(parsed, "data")
+  expect_is(parsed$data$repository, "list")
+  expect_identical(parsed$data$repository$name, params$repo)
+  
+  # no variables
+  expect_error(aa$exec(qry$queries$repos), "not one passed")
+  
+  # missing variable
+  expect_error(
+      aa$exec(qry$queries$repos, variables = list(owner_name = "ropensci")), 
+      "variable `repo` is not found")
+  
+  # null variable
+  out2 <- aa$exec(qry$queries$repos, variables = list(owner_name = "ropensci", repo = NULL))
+  expect_is(out2, "character")
+  
+  parsed2 <- jsonlite::fromJSON(out2)
+  expect_is(parsed2, "list")
+  expect_named(parsed2, "errors")
+  expect_match(parsed2$errors$message, "invalid value")
+})

--- a/tests/testthat/test-GraphqlClient.R
+++ b/tests/testthat/test-GraphqlClient.R
@@ -124,3 +124,44 @@ test_that("GraphqlClient class fails well", {
   expect_error(rr$fragment(), "argument \"name\" is missing")
   expect_error(rr$exec(), "argument \"query\" is missing")
 })
+
+test_that("GraphqlClient construction works with parameters", {
+      skip_on_cran()
+      
+      token <- Sys.getenv("GITHUB_GRAPHQL_TOKEN")
+      aa <- GraphqlClient$new(
+          url = "https://api.github.com/graphql",
+          headers = list(Authorization = paste0("Bearer ", token))
+      )
+      
+      # ping method
+      expect_true(aa$ping())
+            
+      qry <- Query$new()
+      qry$query('repos', 'query getRepo($owner_name: String!, $repo: String!){
+                repository(owner: $owner_name, name: $repo) {
+                  name
+                }
+              }')
+      params <- list(owner_name = "ropensci", repo = "ghql")
+      # execute method
+      out <- aa$exec(qry$queries$repos, variables = params)
+      expect_is(out, "character")
+      expect_match(out, "ghql")
+      
+      parsed <- jsonlite::fromJSON(out)
+      expect_is(parsed, "list")
+      expect_named(parsed, "data")
+      expect_is(parsed$data$repository, "list")
+      expect_identical(parsed$data$repository$name, params$repo)
+      
+      # no variables
+      expect_error(aa$exec(qry$queries$repos), "not one passed")
+      
+      # missing variable
+      expect_error(
+          aa$exec(qry$queries$repos, variables = list(owner_name = "ropensci")), 
+          "variable `repo` is null")
+      
+      
+    })


### PR DESCRIPTION
## Description

* modified regex to find variables to match the spec - https://spec.graphql.org/October2021/#sec-Language.Variables
* added test with variables
* minor typo fix

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
Previously one couldn't use underscores in the variable names, now it is possible:
```
qry <- Query$new()$query('repos', '
  query getRepo($owner_name: String!, $repo: String!) {
    repository(owner: $owner_name, name: $repo) {
      name
    }
  }
')
```
See the test code for full example - https://github.com/mnazarov/ghql/blob/master/tests/testthat/test-GraphqlClient.R#L131-L148
